### PR TITLE
Fix product management permissions and enhance UI interactions

### DIFF
--- a/convex/households_members/queries.ts
+++ b/convex/households_members/queries.ts
@@ -16,7 +16,7 @@ export const getHouseholdMembers = queryWithRLS({
       role: member.role,
       status: member.status,
       canEditHousehold: member.canEditHousehold,
-      canManageProducts: member.canManageProducts ?? false,
+      canManageProducts: member.canManageProducts,
       householdId: member.householdId,
       user: nullThrows(await ctx.db.get(member.userId)),
     }));

--- a/convex/households_members/schema.ts
+++ b/convex/households_members/schema.ts
@@ -18,7 +18,7 @@ export const householdMembersSchema = defineTable({
 
   // Permissions
   canEditHousehold: v.boolean(),
-  canManageProducts: v.optional(v.boolean()), // TODO: Revert back to v.boolean()
+  canManageProducts: v.boolean(),
 })
   .index('by_userId', ['userId'])
   .index('by_householdId', ['householdId'])

--- a/src/components/households-members/permissions-config.ts
+++ b/src/components/households-members/permissions-config.ts
@@ -36,6 +36,12 @@ export const PERMISSIONS_CONFIG: AllValuesArray<PermissionKeys> = [
     description: 'Permet de modifier les informations du foyer',
     defaultValue: false,
   },
+  {
+    key: 'canManageProducts',
+    label: 'Gérer les produits',
+    description: 'Permet de gérer les produits du foyer',
+    defaultValue: false,
+  },
 ];
 
 /**

--- a/src/components/products/product-actions.tsx
+++ b/src/components/products/product-actions.tsx
@@ -22,6 +22,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
 import { ProductForm, type ProductFormValues } from './product-form';
 
 interface ProductActionsProps {
@@ -67,26 +68,34 @@ export function ProductActions({ product, householdId }: ProductActionsProps) {
   return (
     <>
       <div className="flex items-center gap-1">
-        <Button
-          variant="ghost"
-          size="icon"
-          className="w-8 h-8"
-          onClick={() => setIsEditDialogOpen(true)}
-          title="Modifier"
-        >
-          <PenIcon className="w-4 h-4" />
-          <span className="sr-only">Modifier</span>
-        </Button>
-        <Button
-          variant="ghost"
-          size="icon"
-          className="w-8 h-8 text-destructive hover:text-destructive"
-          onClick={() => setIsDeleteDialogOpen(true)}
-          title="Supprimer"
-        >
-          <TrashIcon className="w-4 h-4" />
-          <span className="sr-only">Supprimer</span>
-        </Button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="w-8 h-8"
+              onClick={() => setIsEditDialogOpen(true)}
+            >
+              <PenIcon className="w-4 h-4" />
+              <span className="sr-only">Modifier</span>
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Modifier</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="w-8 h-8 text-destructive hover:text-destructive"
+              onClick={() => setIsDeleteDialogOpen(true)}
+            >
+              <TrashIcon className="w-4 h-4" />
+              <span className="sr-only">Supprimer</span>
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Supprimer</TooltipContent>
+        </Tooltip>
       </div>
 
       {/* Edit Dialog */}

--- a/src/components/products/products-toolbar.tsx
+++ b/src/components/products/products-toolbar.tsx
@@ -1,7 +1,10 @@
-import type { Doc } from 'convex/_generated/dataModel';
+import { useConvexMutation } from '@convex-dev/react-query';
+import { useMutation } from '@tanstack/react-query';
+import { api } from 'convex/_generated/api';
 import { CATEGORY_DISPLAY_NAMES } from 'convex/types';
 import { PlusIcon, SearchIcon, XIcon } from 'lucide-react';
 import { useMemo, useState } from 'react';
+import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -21,20 +24,32 @@ import {
 import { ProductForm, type ProductFormValues } from './product-form';
 
 export interface ProductsToolbarProps {
-  products: Doc<'products'>[];
-  onCreate: (values: ProductFormValues) => void;
-  isCreating: boolean;
+  householdId: string;
   onFilter: (data: { search: string; category: string }) => void;
 }
 
 export function ProductsToolbar({
-  onCreate,
-  isCreating,
   onFilter,
+  householdId,
 }: ProductsToolbarProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [search, setSearch] = useState('');
   const [category, setCategory] = useState('all');
+
+  const { mutate, isPending } = useMutation({
+    mutationFn: useConvexMutation(api.products.mutations.createProduct),
+    onSuccess: () => {
+      toast.success('Produit créé avec succès');
+      setIsOpen(false);
+    },
+  });
+
+  const handleCreateProduct = (values: ProductFormValues) => {
+    mutate({
+      publicId: householdId,
+      ...values,
+    });
+  };
 
   const handleSearchChange = (value: string) => {
     setSearch(value);
@@ -106,7 +121,7 @@ export function ProductsToolbar({
           <DialogHeader>
             <DialogTitle>Nouveau produit</DialogTitle>
           </DialogHeader>
-          <ProductForm onSubmit={onCreate} isLoading={isCreating} />
+          <ProductForm onSubmit={handleCreateProduct} isLoading={isPending} />
         </DialogContent>
       </Dialog>
     </div>

--- a/src/routes/_authed/products.tsx
+++ b/src/routes/_authed/products.tsx
@@ -1,11 +1,9 @@
-import { convexQuery, useConvexMutation } from '@convex-dev/react-query';
-import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
+import { convexQuery } from '@convex-dev/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { createFileRoute, redirect } from '@tanstack/react-router';
 import { api } from 'convex/_generated/api';
 import { useMemo, useState } from 'react';
-import { toast } from 'sonner';
 import { createProductColumns } from '@/components/products/product-columns';
-import type { ProductFormValues } from '@/components/products/product-form';
 import { ProductsToolbar } from '@/components/products/products-toolbar';
 import { DataTable } from '@/components/table/data-table';
 
@@ -31,7 +29,7 @@ export const Route = createFileRoute('/_authed/products')({
 
     return {
       breadcrumbs: 'Produits',
-      householdId: householdId as string,
+      householdId: householdId,
     };
   },
 });
@@ -46,24 +44,6 @@ function RouteComponent() {
   const { data: products = [] } = useSuspenseQuery(
     convexQuery(api.products.queries.getProducts, { publicId: householdId }),
   );
-
-  const createProductMutation = useMutation({
-    mutationFn: useConvexMutation(api.products.mutations.createProduct),
-    onSuccess: () => {
-      toast.success('Produit créé avec succès');
-    },
-  });
-
-  const handleCreateProduct = (values: ProductFormValues) => {
-    createProductMutation.mutate({
-      publicId: householdId,
-      icon: values.icon,
-      name: values.name,
-      description: values.description || undefined,
-      category: values.category,
-      defaultUnit: values.defaultUnit,
-    });
-  };
 
   const filtered = useMemo(() => {
     return products.filter((p) => {
@@ -95,12 +75,7 @@ function RouteComponent() {
         </p>
       </div>
 
-      <ProductsToolbar
-        products={products}
-        onCreate={handleCreateProduct}
-        isCreating={createProductMutation.isPending}
-        onFilter={setFilters}
-      />
+      <ProductsToolbar householdId={householdId} onFilter={setFilters} />
 
       {filtered.length === 0 ? (
         <div className="flex flex-col justify-center items-center gap-4 bg-muted/30 py-16 border rounded-md text-center">
@@ -114,10 +89,7 @@ function RouteComponent() {
           </div>
         </div>
       ) : (
-        <DataTable
-          columns={columns}
-          data={filtered.map((p) => ({ ...p, id: p._id }))}
-        />
+        <DataTable columns={columns} data={filtered} />
       )}
     </div>
   );


### PR DESCRIPTION
Update the `canManageProducts` field to be mandatory in the schema and adjust the permissions configuration accordingly. Add tooltips to the edit and delete buttons in the `ProductActions` component for improved user experience. Refactor the `ProductsToolbar` to facilitate product creation while integrating the `householdId`.